### PR TITLE
Clean up and parameterize dockerfile and compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,17 @@
 # Use an official Python runtime as a parent image
 FROM python:3.10-slim
 
+# Default values for environment variable used in the image
+ENV PORT=8000
+ENV MAIN_PAGE=webapp/Forside.py
+ENV DATABASE_URL=sqlite:///data/data.db
+
+# Define expected mount point for database data file
+VOLUME /data
+
+# Expose the port Streamlit runs on
+EXPOSE $PORT
+
 # Set the working directory in the container
 WORKDIR /app
 
@@ -16,8 +27,5 @@ COPY . /app
 # Create a directory for the database and set permissions
 RUN mkdir -p /data && chmod -R 755 /data
 
-# Expose the port Streamlit runs on
-EXPOSE 8501
-
 # Run the Streamlit app
-CMD ["streamlit", "run", "webapp/Forside.py", "--server.port=8501", "--server.address=0.0.0.0"]
+CMD ["/bin/sh", "-c", "streamlit run ${MAIN_PAGE} --server.port=${PORT} --server.address=0.0.0.0"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   streamlit:
     build:
@@ -10,6 +9,8 @@ services:
       - db-data:/data  # Mount the directory where your SQLite database is stored
     environment:
       - DATABASE_URL=sqlite:///data/investerings_database.db  # Path to your SQLite DB
+      - PORT=8501
+      - MAIN_PAGE=webapp/Forside.py
 
 volumes:
   db-data:


### PR DESCRIPTION
Changes:

In dockerfile
- Added `PORT` and `MAIN_PAGE` environment variables with default values
- Added a default value for `DATABASE_URL` to make its existence more visible
- Use PORT variable when declaring exposed ports
- Explicitly define the `data` volume. It doesn't change anything but is good for documentation.
- Rewrite `CMD` to use the variables. Unfortunately, the Json list format does not support evaluation of variables. The workaround is to call a shell which then runs the command. This will in turn cause the environment variables to be correctly evaluated.

In compose file:

- Remove version. It is deprecated and therefore no longer necessary.
- Define `PORT` and `MAIN_PAGE` values
