### PR TITLE
Add Azure Container Registry login to docker build workflow

### DIFF
--- a/.github/workflows/main_kommunale-investeringer.yml
+++ b/.github/workflows/main_kommunale-investeringer.yml
@@ -11,7 +11,6 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY_NAME: gravercentret.azurecr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
@@ -40,11 +39,18 @@ jobs:
           tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_93E6EA7B0E9F43BC9B4310523F9CFEB2 }}
           subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_FC14C2B06F754714B8F8A93F7F2FC3C6 }}
 
+      - name: Login to Azure Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ vars.ACR_REGISTRY_NAME }}
+          username: ${{ vars.ACR_TOKEN_NAME }}
+          password: ${{ secrets.ACR_TOKEN_PASSWORD }}
+          
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: false
+          push: true
           tags: |
-            ${{ env.REGISTRY_NAME }}/${{ env.IMAGE_NAME }}:latest
-            ${{ env.REGISTRY_NAME }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ vars.ACR_REGISTRY_NAME }}/${{ env.IMAGE_NAME }}:latest
+            ${{ vars.ACR_REGISTRY_NAME }}/${{ env.IMAGE_NAME }}:${{ github.sha }}


### PR DESCRIPTION
The username and password for `docker/login-action` are stored as repository level vars and secrets respectively. They reference an access token on the Azure Container Registry. The name of the access token is used as username.

The access token password can not be retrieved again after creation, neither from the Azure Portal nor from the Github secret. If you need to change the password, you need to regenerate the password for the token in the Azure Portal, and then update the secret in the Github repository secret.

I have also moved the Azure container registry name to be a repository level variable. This and the other variables should probably be changed to org-level variables, so that they can be used from several repositories.