### PR TITLE
Use Org secrets instead of repo secrets for github workflow

### DIFF
--- a/.github/workflows/main_kommunale-investeringer.yml
+++ b/.github/workflows/main_kommunale-investeringer.yml
@@ -35,16 +35,16 @@ jobs:
       - name: Login to Azure
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_16CB276D99CB40DB9752309DBCA608A2 }}
-          tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_93E6EA7B0E9F43BC9B4310523F9CFEB2 }}
-          subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_FC14C2B06F754714B8F8A93F7F2FC3C6 }}
+          client-id: ${{ secrets.AZUREAPPSERVICE_DEPLOYMENT_USER_CLIENTID }}
+          tenant-id: ${{ secrets.AZUREAPPSERVICE_GRAVERCENTRET_TENANTID }}
+          subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID }}
 
       - name: Login to Azure Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ vars.ACR_REGISTRY_NAME }}
-          username: ${{ vars.ACR_TOKEN_NAME }}
-          password: ${{ secrets.ACR_TOKEN_PASSWORD }}
+          registry: ${{ vars.ACR_GRAVERCENTRET_REGISTRY_NAME }}
+          username: ${{ vars.ACR_GRAVERCENTRET_TOKEN_NAME }}
+          password: ${{ secrets.ACR_GRAVERCENTRET_TOKEN_PASSWORD }}
           
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Tested by manually running the pipeline on the branch: [Build and push Docker image to Azure Container Registry](https://github.com/gravercentret/kommunale_investeringer_app/actions/runs/13434489361)